### PR TITLE
Update for 1.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 1.0.0
+
+2019-04-12
+
+Initial release.

--- a/README.md
+++ b/README.md
@@ -38,5 +38,6 @@ The `app-context` attribute clarifies the scope and context of the help linked.
 #### url
 
 The `url` attribute tells the web component where the link should take the user.
-Host-relative links open in the same tab; absolute links open in a new tab (via
-`rel='noopener noreferrer'`).
+
+TODO: Eventually, host-relative links open in the same tab; absolute links open
+in a new tab (via `rel='noopener noreferrer'`).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myuw-web-components/myuw-help-link",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": "Stylized hyperlink to help content.",
   "module": "dist/myuw-help-link.min.mjs",
   "browser": "dist/myuw-help-link.min.js",


### PR DESCRIPTION
Bump version number to 1.0.0, and update README to reflect reality that auto-setting the `rel` attribute on the link isn't implemented yet.