### PR TITLE
open external links in new tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.1.0
+
+If the `url` attribute begins with `http`, instructs browser to open the link in
+a new tab (`target='_blank'` and `rel='noopener noreferrer'`)
+
 ## 1.0.0
 
 2019-04-12

--- a/README.md
+++ b/README.md
@@ -39,5 +39,5 @@ The `app-context` attribute clarifies the scope and context of the help linked.
 
 The `url` attribute tells the web component where the link should take the user.
 
-TODO: Eventually, host-relative links open in the same tab; absolute links open
-in a new tab (via `rel='noopener noreferrer'`).
+Absolute links (starting with `http`) open in a new tab (via `target='_blank'`
+with the page-jacking-prevention workaround of `rel='noopener noreferrer'`).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myuw-web-components/myuw-help-link",
-  "version": "1.0.0",
+  "version": "1.1.0-SNAPSHOT",
   "description": "Stylized hyperlink to help content.",
   "module": "dist/myuw-help-link.min.mjs",
   "browser": "dist/myuw-help-link.min.js",

--- a/src/myuw-help-link.html
+++ b/src/myuw-help-link.html
@@ -11,8 +11,7 @@
 
 <a
   id="help-link"
-  href="https://www.example.edu/from-myuw-help-link"
-  rel="noopener noreferrer">
+  href="https://www.example.edu/from-myuw-help-link">
   Help and resources
   <!-- material.io launch icon-->
   <svg id="launch-icon" xmlns="http://www.w3.org/2000/svg"

--- a/src/myuw-help-link.js
+++ b/src/myuw-help-link.js
@@ -54,6 +54,13 @@ class MyUWHelpLink extends HTMLElement {
 
     this.shadowRoot.getElementById('help-link').setAttribute(
       "href", this['url']);
+
+    if (this['url'].startsWith("http")) {
+      this.shadowRoot.getElementById('help-link').setAttribute(
+        "rel", "noopener noreferrer");
+      this.shadowRoot.getElementById('help-link').setAttribute(
+        "target", "_blank");
+    }
   }
 }
 


### PR DESCRIPTION
When the help URL linked to starts with `http` (so, `http://` or `https://`), open it in a new tab (via `target='_blank'` de-fanged with `rel='noopener noreferrer'`).